### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -1,6 +1,9 @@
 version: 2.1
 description: >
-  Encapsulates interactions with Lambdatest tunnel
+  Encapsulates interactions with Lambdatest tunnel.
+display:
+  home_url: https://www.lambdatest.com/
+  source_url: https://github.com/LambdaTest/Lambdatest-circleci-orb
 
 commands:
   install:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.