### PR TITLE
fix: Replace LambdaTest brand name with TestMu AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Run NightWatch with CircleCI ORB on TestMu AI (Formerly LambdaTest)
+﻿# Run NightWatch with CircleCI ORB on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -10,7 +10,7 @@
 
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-With TestMu AI (Formerly LambdaTest), you can run NightWatch tests via CircleCI ORBs across real browsers and operating systems. This sample shows how to configure NightWatch with the LambdaTest CircleCI ORB to run on the TestMu AI cloud.
+With TestMu AI (Formerly LambdaTest), you can run NightWatch tests via CircleCI ORBs across real browsers and operating systems. This sample shows how to configure NightWatch with the TestMu AI (Formerly LambdaTest) CircleCI ORB to run on the TestMu AI cloud.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
@@ -20,7 +20,7 @@ With TestMu AI (Formerly LambdaTest), you can run NightWatch tests via CircleCI 
 - [Node.js](https://nodejs.org/en/) installed on your system.
 - A TestMu AI (Formerly LambdaTest) account. [Sign up here](https://www.testmuai.com/register/).
 - Your TestMu AI Username and Access Key from your [profile page](https://accounts.lambdatest.com/detail/profile).
-- A CircleCI account with the LambdaTest ORB enabled.
+- A CircleCI account with the TestMu AI (Formerly LambdaTest) ORB enabled.
 
 ### Setup
 
@@ -60,7 +60,7 @@ View results in the [TestMu AI Automation Dashboard](https://automation.lambdate
 
 #### Run tests via CircleCI ORB
 
-Configure your `.circleci/config.yml` to use the LambdaTest ORB:
+Configure your `.circleci/config.yml` to use the TestMu AI (Formerly LambdaTest) ORB:
 
 ```yaml
 version: 2.1


### PR DESCRIPTION
Replaces all standalone LambdaTest brand mentions with TestMu AI (Formerly LambdaTest) in body text and TestMu AI in H1 title. Code blocks, URLs, badge HTML, and boilerplate are untouched.