### PR TITLE
fix: README - align with TestMu AI branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# Run NightWatch with CircleCI ORB on TestMu AI (Formerly LambdaTest)
+# CircleCI Orb for TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
-  <a href="https://circleci.com/developer/orbs/orb/lambdatest/lambda-tunnel"><img src="https://img.shields.io/badge/CircleCI-ORB-343434.svg?style=for-the-badge&labelColor=000" alt="CircleCI ORB"></a>
   <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
 
@@ -10,7 +9,7 @@
 
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-With TestMu AI (Formerly LambdaTest), you can run NightWatch tests via CircleCI ORBs across real browsers and operating systems. This sample shows how to configure NightWatch with the TestMu AI (Formerly LambdaTest) CircleCI ORB to run on the TestMu AI cloud.
+With this CircleCI Orb, you can run NightWatch tests via CircleCI across real browsers and operating systems on TestMu AI (Formerly LambdaTest). This sample shows how to configure NightWatch with the CircleCI Orb to run on the TestMu AI cloud.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
@@ -20,7 +19,7 @@ With TestMu AI (Formerly LambdaTest), you can run NightWatch tests via CircleCI 
 - Node.js installed on your system.
 - A TestMu AI (Formerly LambdaTest) account. Sign up here.
 - Your TestMu AI Username and Access Key from your profile page.
-- A CircleCI account with the TestMu AI (Formerly LambdaTest) ORB enabled.
+- A CircleCI account with the TestMu AI (Formerly LambdaTest) Orb enabled.
 
 ### Setup
 
@@ -58,9 +57,9 @@ Run tests in parallel:
 
 View results in the TestMu AI Automation Dashboard.
 
-#### Run tests via CircleCI ORB
+#### Run tests via CircleCI Orb
 
-Configure your `.circleci/config.yml` to use the TestMu AI (Formerly LambdaTest) ORB:
+Configure your `.circleci/config.yml` to use the TestMu AI (Formerly LambdaTest) Orb:
 
 ```yaml
 version: 2.1
@@ -97,7 +96,7 @@ To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 - [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
 - [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
-The CircleCI ORB (`lambdatest/lambda-tunnel`) automatically manages tunnel setup and teardown for each job using the `lambdatest/with_tunnel` executor. Set a unique `tunnel_name` per job to identify each tunnel session.
+The CircleCI Orb (`lambdatest/lambda-tunnel`) automatically manages tunnel setup and teardown for each job using the `lambdatest/with_tunnel` executor. Set a unique `tunnel_name` per job to identify each tunnel session.
 
 ## Contributions
 


### PR DESCRIPTION
Aligns README with TestMu AI branding: updated H1 title, badge block, brand names, and links per guidelines.